### PR TITLE
Implement intercom booting for logged out users

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ meteor add percolate:intercom
 
 Ensure you have `Meteor.settings.intercom.secret` and `Meteor.settings.public.intercom.id` defined to the values provided to you by Intercom.
 
+Some Intercom subscription packages allow for anonymous users.  To enable the use of anonymous users, set `Meteor.settings.public.intercom.allowAnonymous` to `true`.
+
 By default, the package will send up the user's id, creation date, and hash (if defined, see below). To send custom data, set:
 
 ```js
@@ -28,11 +30,33 @@ IntercomSettings.userInfo = function(user, info) {
 
 If you need to wait on a user subscription for e.g. the hash to come down, you can return `false` in your `userInfo` function to tell the package to wait.
 
+```js
+IntercomSettings.userInfo = function (user, info) {
+  if (!user.intercomHash) {
+    return false; // the hash isn't loaded to the users collection yet. come back later.
+  }
+  // ...
+}
+```
+
+If you want to add fields sent to intercom for an anonymous user, you can add them through in the `anonymousInfo` function.
+
+```js
+IntercomSettings.anonymousInfo = function ( info ) {
+  // check all router subscriptions have loaded
+  if (!Router.current() || !Router.current().ready())
+    return false;
+
+  info.anonymous = true;
+  return;
+};
+```
+
 ## Notes
 
-This package will automatically subscribe the current user to the `currentUserIntercomHash` publication which will add an `intercomHash` property to your user documents enabling the use of intercom's secure mode. 
+This package will automatically subscribe the current user to the `currentUserIntercomHash` publication which will add an `intercomHash` property to your user documents enabling the use of intercom's secure mode.
 
-## License 
+## License
 
 MIT. (c) Percolate Studio, maintained by Tom Coleman (@tmeasday)
 

--- a/intercom_client.js
+++ b/intercom_client.js
@@ -41,7 +41,7 @@ Meteor.startup(function() {
           }
         } else {
           booted = false;
-          console.log('shutdown')
+          // console.log('shutdown')
           return Intercom('shutdown');
         }
       }
@@ -58,8 +58,7 @@ Meteor.startup(function() {
         var type = booted ? 'update': 'boot';
 
         console.log(type, info)
-        console.log(Intercom(type, info));
-
+        Intercom(type, info);
         booted = true;
       }
     });

--- a/intercom_client.js
+++ b/intercom_client.js
@@ -57,7 +57,7 @@ Meteor.startup(function() {
       if (info) {
         var type = booted ? 'update': 'boot';
 
-        console.log(type, info)
+        // console.log(type, info)
         Intercom(type, info);
         booted = true;
       }

--- a/intercom_client.js
+++ b/intercom_client.js
@@ -33,15 +33,15 @@ Meteor.startup(function() {
       var ready;
 
       if (!user) {
-        if (Meteor.settings.public.intercom.allowAnonymous === true) { //typesafe check
+        if (Meteor.settings.public.intercom.allowAnonymous === true) {
           if (IntercomSettings.anonymousInfo) {
             ready = IntercomSettings.anonymousInfo(info);
             if (ready === false)
               return;
           }
         } else {
-          booted = false;
           // console.log('shutdown')
+          booted = false;
           return Intercom('shutdown');
         }
       }

--- a/intercom_server.js
+++ b/intercom_server.js
@@ -22,3 +22,10 @@ Meteor.publish('currentUserIntercomHash', function() {
   }
   this.ready();
 });
+
+Meteor.methods({
+  IntercomHashFunc : function(userId) {
+    check(userId, String);
+    return IntercomHash(userId);
+  }
+});

--- a/intercom_server.js
+++ b/intercom_server.js
@@ -4,7 +4,7 @@ var crypto = Npm.require('crypto');
 
 // returns undefined if there is no secret
 var IntercomHash =  function(userId) {
-  var secret = Meteor.settings && 
+  var secret = Meteor.settings &&
       Meteor.settings.intercom && Meteor.settings.intercom.secret;
 
   if (secret) {
@@ -16,7 +16,7 @@ var IntercomHash =  function(userId) {
 Meteor.publish('currentUserIntercomHash', function() {
   if (this.userId) {
     var intercomHash = IntercomHash(this.userId);
-  
+
     if (intercomHash)
       this.added("users", this.userId, {intercomHash: intercomHash});
   }

--- a/intercom_server.js
+++ b/intercom_server.js
@@ -22,10 +22,3 @@ Meteor.publish('currentUserIntercomHash', function() {
   }
   this.ready();
 });
-
-Meteor.methods({
-  IntercomHashFunc : function(userId) {
-    check(userId, String);
-    return IntercomHash(userId);
-  }
-});


### PR DESCRIPTION
With the intercom [acquire package](http://docs.intercom.io/Intercom-for-customer-communication/the-acquire-package-explained), you can use the intercom messenger for users who are not logged into your app, and therefore do not have a user id.  
This code expands the API to allow for this, adding settings to enable it, and keeping with the original conventions of laying out the functions.  