### PR TITLE
Wrap intercom settings check inside Meteor.startup

### DIFF
--- a/intercom_client.js
+++ b/intercom_client.js
@@ -1,11 +1,13 @@
 // We *must* have the intercom id set otherwise the intercom loader script throws
 // exceptions. Warn people about this.
-if (!(Meteor.settings
-   && Meteor.settings.public
-   && Meteor.settings.public.intercom
-   && Meteor.settings.public.intercom.id)) {
-  console.warn("You must set Meteor.settings.public.intercom.id to use percolate:interom");
-}
+Meteor.startup(function() {
+  if (!(Meteor.settings
+    && Meteor.settings.public
+    && Meteor.settings.public.intercom
+    && Meteor.settings.public.intercom.id)) {
+    console.warn("You must set Meteor.settings.public.intercom.id to use percolate:interom");
+  }
+});
 
 Meteor.subscribe('currentUserIntercomHash');
 


### PR DESCRIPTION
If settings are defined by top-level JavaScript instead of `settings.json`, then the warning will be shown even if `intercom.id` is already defined.

Wrapping this check inside `Meteor.startup` help ensure that we perform the check only after all settings are initialized.